### PR TITLE
fix: set the default column when there is no terminal

### DIFF
--- a/packages/spec_cli/lib/src/renderer.dart
+++ b/packages/spec_cli/lib/src/renderer.dart
@@ -138,7 +138,7 @@ class BacktrackingRenderer implements Renderer {
       );
       final lastOutputHeight = computeOutputHeight(
         diff.previous,
-        terminalWidth: stdout.terminalColumns,
+        terminalWidth: stdout.hasTerminal ? stdout.terminalColumns : 80,
       );
       toRender = diff.next;
 


### PR DESCRIPTION
close #19 

If no terminal is attached to stdout, a `StdoutException` is thrown. Set the default columns when there is no terminal.