### PR TITLE
fix(spec_cli): use fix `riverpod` as a quick fix to skip the migration to Riverpod 2.0.0

### DIFF
--- a/packages/spec_cli/pubspec.yaml
+++ b/packages/spec_cli/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   meta: ^1.7.0
   path: ^1.8.0
   pubspec: ^2.0.1
-  riverpod: ^2.0.0-dev.3
+  riverpod: 2.0.0-dev.3
   test: ^1.17.8
 
 dev_dependencies:


### PR DESCRIPTION
The clean solution would to migrate to Riverpod 2.0.0. However, at the moment I don't have the time for this so I provided to a quick fix (using the a fixed riverpod version).

Closes #28