### PR TITLE
fix: cursor and newline missing when running without --watch

### DIFF
--- a/packages/spec_cli/lib/src/command_runner.dart
+++ b/packages/spec_cli/lib/src/command_runner.dart
@@ -231,7 +231,12 @@ Future<int> spec({
         final sub = ref.listen($exitCode.future, (previous, current) {});
 
         // Outside of watch mode, quit as soon we know what the exit code should be
-        return sub.read();
+        return () {
+          return sub.read()
+            ..then((_) => stdout
+              ..write(VT100.showCursor)
+              ..write('\n'));
+        }();
       }
     } finally {
       stdout

--- a/packages/spec_cli/lib/src/command_runner.dart
+++ b/packages/spec_cli/lib/src/command_runner.dart
@@ -231,12 +231,11 @@ Future<int> spec({
         final sub = ref.listen($exitCode.future, (previous, current) {});
 
         // Outside of watch mode, quit as soon we know what the exit code should be
-        return () {
-          return sub.read()
-            ..then((_) => stdout
-              ..write(VT100.showCursor)
-              ..write('\n'));
-        }();
+        final future = sub.read();
+        unawaited(future.then((_) => stdout
+          ..write(VT100.showCursor)
+          ..write('\n')));
+        return future;
       }
     } finally {
       stdout


### PR DESCRIPTION
Fixes #46 

# Changes proposed

Apparently the `finally` block containing `VT100.showCursor` and `VT100.newline` was not executed because the function was being `return`ed from within the `try` block.

Now it's fixed. I didn't write tests for it because I'm not familiar with this project's codebase at all.

# Check List (Check all the applicable boxes)

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.